### PR TITLE
docs: add AUTOSYNC.md — generated files notice

### DIFF
--- a/.github/AUTOSYNC.md
+++ b/.github/AUTOSYNC.md
@@ -1,0 +1,19 @@
+# Automated Sync
+
+Rule files in this repository are **generated** from the canonical phrase list at [Open-Paws/no-animal-violence](https://github.com/Open-Paws/no-animal-violence).
+
+## Do not edit generated files directly
+
+The following files are overwritten by the `propagate.yml` workflow whenever the canonical repo changes:
+
+- `action.yml`
+
+To add, change, or remove a rule: edit `rules.yaml` in the canonical repo, then the propagation workflow will open a PR here automatically.
+
+## PR labels
+
+Automated sync PRs carry the label `automated-sync`. These should be reviewed for correctness and merged promptly.
+
+## Questions
+
+See the [canonical repo](https://github.com/Open-Paws/no-animal-violence) for architecture docs.


### PR DESCRIPTION
Adds `.github/AUTOSYNC.md` to document that `action.yml` is generated from the canonical repo and should not be edited directly.\n\nPart of the push-model automation system in [Open-Paws/no-animal-violence#33](https://github.com/Open-Paws/no-animal-violence/pull/33).