### PR TITLE
feat: add fail-on-findings input (fixes #15)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'GitHub token for PR annotations'
     required: false
     default: ${{ github.token }}
+  fail-on-findings:
+    description: 'Fail the action if violations are found (default: false for gradual adoption)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -2641,6 +2645,11 @@ runs:
     - name: Run animal violence language scan
       shell: bash
       run: |
-        woke --exit-1-on-failure \
-          --config /tmp/.woke.yaml \
-          ${{ inputs.paths }}
+        if [ "${{ inputs.fail-on-findings }}" = "true" ]; then
+          woke --exit-1-on-failure \
+            --config /tmp/.woke.yaml \
+            ${{ inputs.paths }}
+        else
+          woke --config /tmp/.woke.yaml \
+            ${{ inputs.paths }}
+        fi


### PR DESCRIPTION
## Changes\n\n- Adds `fail-on-findings` boolean input (default `false`) to control whether `woke --exit-1-on-failure` is used.\n- Enables gradual adoption: repos can scan + annotate PRs without blocking CI during transition.\n\nCloses #15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable `fail-on-findings` input parameter to control workflow behavior when scan findings are detected (defaults to false, allowing workflows to continue regardless of results).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->