### PR TITLE
fix(scan): skip canonical dictionary files to avoid self-reference false positives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ build/
 *.swo
 coverage/
 .turbo/
+
+# Python test caches
+__pycache__/
+.pytest_cache/

--- a/.wokeignore
+++ b/.wokeignore
@@ -7,3 +7,5 @@ scan.py
 # AGENTS.md and README.md document the detected patterns as usage examples
 AGENTS.md
 README.md
+# Test fixtures contain the prohibited phrases as scanner inputs by design
+tests/test_self_reference_allowlist.py

--- a/scan.py
+++ b/scan.py
@@ -1328,6 +1328,22 @@ SCAN_EXTENSIONS = {
 # Directories to always skip regardless of .wokeignore
 SKIP_DIRS = {".git", "node_modules", "vendor"}
 
+# Files to always skip regardless of .wokeignore. These are canonical dictionary
+# files that define the prohibited phrases as examples — flagging them is a
+# self-reference false positive. Matched against the path with forward slashes,
+# from any depth, so consumer repos carrying these rule files are covered.
+SKIP_FILES_PATTERNS = [
+    re.compile(r"(^|/)\.claude/rules/advocacy-domain\.md$"),
+    re.compile(r"(^|/)\.claude/rules/speciesist-language\.md$"),
+]
+
+
+def is_self_reference_file(path_str):
+    """Return True if path is one of the canonical dictionary files that
+    define the prohibited phrases as examples and so must never be scanned."""
+    normalised = path_str.replace("\\", "/")
+    return any(pat.search(normalised) for pat in SKIP_FILES_PATTERNS)
+
 # ---------------------------------------------------------------------------
 # Severity ordering
 # ---------------------------------------------------------------------------
@@ -1389,7 +1405,9 @@ def iter_files(scan_paths, ignore_patterns):
             print(f"::warning::scan.py: path does not exist: {raw_path}", flush=True)
             continue
         if base.is_file():
-            if base.suffix in SCAN_EXTENSIONS and not is_ignored(str(base), ignore_patterns):
+            if (base.suffix in SCAN_EXTENSIONS
+                    and not is_self_reference_file(str(base))
+                    and not is_ignored(str(base), ignore_patterns)):
                 yield base
             continue
         for dirpath, dirnames, filenames in os.walk(base):
@@ -1403,7 +1421,9 @@ def iter_files(scan_paths, ignore_patterns):
             for filename in filenames:
                 full = Path(dirpath) / filename
                 rel = str(full)
-                if full.suffix in SCAN_EXTENSIONS and not is_ignored(rel, ignore_patterns):
+                if (full.suffix in SCAN_EXTENSIONS
+                        and not is_self_reference_file(rel)
+                        and not is_ignored(rel, ignore_patterns)):
                     yield full
 
 

--- a/tests/test_self_reference_allowlist.py
+++ b/tests/test_self_reference_allowlist.py
@@ -1,0 +1,207 @@
+"""Regression tests for the self-reference allowlist in scan.py.
+
+Background: PR #42 added ``is_self_reference_file`` so that canonical
+dictionary files (``.claude/rules/advocacy-domain.md`` and
+``.claude/rules/speciesist-language.md``) are not flagged when they mention
+the prohibited phrases as examples. These files define the very phrases the
+scanner enforces, so flagging them is a self-reference false positive.
+
+These tests pin four behaviours that the adversarial review specified:
+
+1. skip-by-path      - a dictionary file addressed by direct path is skipped
+2. skip-via-walk     - the same file is skipped when discovered via os.walk
+3. real-violations   - the same phrases in a normal file ARE still flagged
+4. path-anchor       - a same-named file outside .claude/rules/ is still flagged
+
+The tests import scan.py as a module and call its real entry points
+(``iter_files`` + ``scan_file``) and also drive ``main()`` as a subprocess to
+assert on exit behaviour end-to-end. They use the scanner's own RULES list,
+so any rule change tracks automatically.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the repo root importable when pytest runs from anywhere (e.g. CI that
+# cds into tests/). scan.py lives at the repo root, one level above tests/.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import scan  # noqa: E402  (path set up above)
+
+# Phrases that the scanner must flag in a normal file. All of these are
+# defined verbatim in scan.RULES, and also appear in the canonical dictionary
+# file .claude/rules/advocacy-domain.md - which is precisely why that file
+# must be allowlisted.
+VIOLATIONS_BODY = """\
+# Notes
+
+We can kill two birds with one stone here.
+No need to beat a dead horse about it.
+There's more than one way to skin a cat.
+"""
+
+# A path that the allowlist must recognise under any parent directory.
+ALLOWLISTED_REL = ".claude/rules/advocacy-domain.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _scan_paths_for(scan_paths):
+    """Run iter_files + scan_file over scan_paths and return the list of
+    (path, findings) tuples with non-zero findings only."""
+    ignore_patterns = []  # no .wokeignore in these fixtures
+    flagged = []
+    for file_path in scan.iter_files(scan_paths, ignore_patterns):
+        findings = scan.scan_file(file_path, scan.RULES)
+        if findings:
+            flagged.append((file_path, findings))
+    return flagged
+
+
+def _run_scan_subprocess(input_paths, cwd):
+    """Invoke scan.py as a subprocess the way action.yml does and return
+    (returncode, stdout). INPUT_SEVERITY=error so only error-severity phrases
+    move the exit code to 1 - matching the production CI invocation."""
+    env = dict(os.environ)
+    env["INPUT_PATHS"] = input_paths
+    env["INPUT_SEVERITY"] = "error"
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scan.py")],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fixture_tree(tmp_path):
+    """Build a tree with:
+      - allowlisted dictionary file containing violations (under .claude/rules/)
+      - a normal notes.md with the same violations
+      - a root-level same-named file NOT under .claude/rules/
+    Returns the tmp_path root.
+    """
+    rules_dir = tmp_path / ".claude" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "advocacy-domain.md").write_text(VIOLATIONS_BODY, encoding="utf-8")
+
+    (tmp_path / "notes.md").write_text(VIOLATIONS_BODY, encoding="utf-8")
+
+    # Root-level file with the SAME basename but NOT under .claude/rules/.
+    # This must still be flagged - proves the regex is path-anchored.
+    (tmp_path / "advocacy-domain.md").write_text(VIOLATIONS_BODY, encoding="utf-8")
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: skip-by-path (direct path arg)
+# ---------------------------------------------------------------------------
+
+def test_skip_by_direct_path(fixture_tree):
+    """A dictionary file addressed by its direct path is NOT flagged."""
+    dict_file = fixture_tree / ALLOWLISTED_REL
+    flagged = _scan_paths_for([str(dict_file)])
+
+    assert dict_file.is_file(), "fixture setup: dictionary file must exist"
+    assert flagged == [], (
+        f"allowlisted dictionary file was flagged as a real violation: {flagged}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: skip-via-walk (discovered through os.walk)
+# ---------------------------------------------------------------------------
+
+def test_skip_via_directory_walk(fixture_tree):
+    """The dictionary file is skipped when the whole tree is walked (not just
+    passed as a direct path). This exercises the os.walk branch of iter_files,
+    which is the branch that fires in production (INPUT_PATHS=. )."""
+    flagged = _scan_paths_for([str(fixture_tree)])
+    flagged_paths = {str(p) for p, _ in flagged}
+
+    dict_file = str(fixture_tree / ALLOWLISTED_REL)
+    assert dict_file not in flagged_paths, (
+        f"dictionary file was flagged during full tree walk: {dict_file} in {flagged_paths}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: real violations still flagged (allowlist is not over-hiding)
+# ---------------------------------------------------------------------------
+
+def test_real_violations_still_flagged(fixture_tree):
+    """The same prohibited phrases in a normal file (notes.md) ARE flagged.
+    This proves the allowlist hides only the dictionary files, not the rules
+    themselves."""
+    flagged = _scan_paths_for([str(fixture_tree)])
+    flagged_paths = {str(p) for p, _ in flagged}
+
+    notes = str(fixture_tree / "notes.md")
+    assert notes in flagged_paths, (
+        f"notes.md with real violations was NOT flagged; allowlist is over-hiding. "
+        f"flagged={flagged_paths}"
+    )
+
+    # Sanity: at least one finding per phrase (3 distinct error/warning/info
+    # phrases). We don't pin the exact count so rule additions don't break it,
+    # but there must be multiple findings - a single match would suggest
+    # scanning stopped early.
+    notes_findings = next(f for p, f in flagged if str(p) == notes)
+    assert len(notes_findings) >= 3, (
+        f"expected >=3 findings in notes.md, got {len(notes_findings)}: {notes_findings}"
+    )
+
+
+def test_real_violations_exit_nonzero(fixture_tree):
+    """End-to-end: invoking scan.py as a subprocess on a tree with real
+    violations exits 1 (matches the production CI invocation)."""
+    rc, stdout = _run_scan_subprocess(str(fixture_tree), cwd=fixture_tree)
+    assert rc == 1, (
+        f"scan.py should exit 1 on real violations; got rc={rc}. stdout:\n{stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: path-anchor boundary
+# ---------------------------------------------------------------------------
+
+def test_path_anchor_root_level_same_name_flagged(fixture_tree):
+    """A root-level advocacy-domain.md (NOT under .claude/rules/) with the
+    same violations IS still flagged. This proves SKIP_FILES_PATTERNS is
+    path-anchored, not matching any same-named file anywhere."""
+    flagged = _scan_paths_for([str(fixture_tree)])
+    flagged_paths = {str(p) for p, _ in flagged}
+
+    root_same_name = str(fixture_tree / "advocacy-domain.md")
+    assert root_same_name in flagged_paths, (
+        f"root-level same-named file was NOT flagged; the allowlist regex is "
+        f"matching by basename instead of by anchored path. flagged={flagged_paths}"
+    )
+
+
+def test_path_anchor_isolated_root_file(tmp_path):
+    """Stronger form of test 4: even when the dictionary file is the ONLY file
+    present and sits at the root (so no .claude/rules/ sibling can confuse
+    the matcher), it is still flagged. Pinned by direct path and by walk."""
+    root_file = tmp_path / "advocacy-domain.md"
+    root_file.write_text(VIOLATIONS_BODY, encoding="utf-8")
+
+    flagged = _scan_paths_for([str(tmp_path)])
+    flagged_paths = {str(p) for p, _ in flagged}
+    assert str(root_file) in flagged_paths, (
+        f"isolated root-level file should be flagged; flagged={flagged_paths}"
+    )

--- a/tests/test_self_reference_allowlist.py
+++ b/tests/test_self_reference_allowlist.py
@@ -156,7 +156,7 @@ def test_real_violations_still_flagged(fixture_tree):
         f"flagged={flagged_paths}"
     )
 
-    # Sanity: at least one finding per phrase (3 distinct error/warning/info
+    # Coherence check: at least one finding per phrase (3 distinct error/warning/info
     # phrases). We don't pin the exact count so rule additions don't break it,
     # but there must be multiple findings - a single match would suggest
     # scanning stopped early.


### PR DESCRIPTION
## Problem

The scanner flags its own dictionary examples in `.claude/rules/advocacy-domain.md` (and the `speciesist-language.md` alt name), failing the NAV check on every repo that carries those rule files. Those files define the prohibited phrases as examples, so flagging them is a self-reference false positive.

Fixes #36.

## Approach

Minimal, obviously-correct allowlist, scoped to the bug as filed:

- Add a `SKIP_FILES_PATTERNS` constant (regex list) alongside the existing `SKIP_DIRS`, covering the two canonical dictionary paths:
  - `.claude/rules/advocacy-domain.md`
  - `.claude/rules/speciesist-language.md` (alt name)
- Add an `is_self_reference_file()` helper that forward-slash-normalises the path and matches from any depth.
- Check it in `iter_files()` at both yield sites (the single-file branch and the `os.walk` branch) so matched files are never scanned, regardless of `.wokeignore`.

The patterns anchor at a path separator (or start of string) so they cannot accidentally match unrelated files like `some-advocacy-domain.md` at the repo root.

This mirrors the approach already used for `action.yml`, `scan.py`, and `.claude/` in this repo's own `.wokeignore` — the standalone `scan.py` lacked the equivalent self-protection for consumer repos that don't ship a matching `.wokeignore`.

## Test results

| Test | Input | Expected | Result |
|------|-------|----------|--------|
| Real violations flagged | `notes.md` with `guinea pig`, `kill two birds with one stone`, `open a can of worms` | 3 findings, exit 1 | PASS (3 findings, exit 1) |
| Dictionary skipped (walk) | `.claude/rules/advocacy-domain.md` containing the same phrases | 0 findings, exit 0 | PASS |
| Alt filename skipped (walk) | `.claude/rules/speciesist-language.md` | 0 findings, exit 0 | PASS |
| Dictionary skipped (direct path arg) | `INPUT_PATHS` set to the dictionary file path | 0 findings, exit 0 | PASS |
| Syntax | `python3 -c 'import ast; ast.parse(...)'` | OK | PASS |

## Notes

- This PR addresses `scan.py` only. `action.yml` is `AUTO-GENERATED` and regenerated upstream by `Open-Paws/no-animal-violence`; a separate change to `gen_action.py`'s `STATIC_FOOTER` is needed to give `woke` (the action's actual scanner) the same default. That is tracked in the issue thread and out of scope for this minimal fix to the standalone scanner.
- No `Sam` / `Open Paws` strings in the diff, commit, or this body (URLs excepted).

## Checklist

- [x] Allowlist is minimal and obviously-correct
- [x] Matches file's existing code style (matches `SKIP_DIRS` / `is_ignored` pattern)
- [x] Tested: real violations still caught; dictionary files skipped
- [x] Bot identity on commit
- [ ] Not merging — left for normal review/gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rule-definition (“self-reference”) Markdown files are now consistently excluded from scanning for both single-file and directory-walk scans.
  * Prevents inconsistent results caused by these files being picked up when they are otherwise scannable.

* **Tests**
  * Added regression tests covering the allowlist behavior, including anchoring to ensure similarly named files outside the intended location are still flagged.
  * Tests run the scanner end-to-end and verify the expected failing behavior on real violations.

* **Chores**
  * Updated ignore settings to exclude Python test cache artifacts (`__pycache__/`, `.pytest_cache/`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->